### PR TITLE
Update dnode dependency version and bump upnode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name" : "upnode",
     "description" : "transactional connection queue for dnode",
-    "version" : "0.4.3",
+    "version" : "0.4.4",
     "repository" : {
         "type" : "git",
         "url" : "git://github.com/substack/upnode.git"
@@ -23,7 +23,7 @@
         "test" : "tap test/*.js"
     },
     "dependencies" : {
-        "dnode" : "~1.0.1"
+        "dnode" : "~1.2.1"
     },
     "devDependencies" : {
         "tap" : "~0.2.6"


### PR DESCRIPTION
This picks up the version of dnode that depends on the latest `weak` module,
which enables node v0.12 compatibility.
